### PR TITLE
v0.2: Web search dedup, /plan mode toggle & workflow optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,14 @@ A lightweight personal AI assistant framework built on Python.
 
 ## Changelog
 
-### v0.2 — Web Search Dedup, Workflow Optimization & Plan Mode
+### v0.2 — Web Search Dedup, Plan Mode & Workflow Optimization
 
-- **Tool call deduplication**: identical tool calls within a single agent turn are now cached and executed only once, eliminating redundant API calls and saving quota.
-- **Search loop detection**: when the agent calls `web_search` 3+ times consecutively, a system nudge is injected to stop searching and synthesize from existing results.
-- **Web research workflow**: system prompt now guides the agent through a structured PLAN → SEARCH → FETCH → SYNTHESIZE pipeline instead of open-ended searching.
-- **Fetch hint**: search results now include a `web_fetch` tip, encouraging the agent to read full page content rather than relying solely on snippets.
-- **`/plan` command**: new slash command that triggers structured task planning before execution. The agent generates a TODO-style checklist, then executes step by step. Plan detection formats output with clipboard emoji in progress messages.
-- **Plan skill** (`always: true`): teaches the agent to automatically plan for complex multi-step tasks (3+ steps, research, comparison, synthesis) even without `/plan`.
-- New modules: `snapagent/orchestrator/dedup.py`, `snapagent/skills/plan/SKILL.md`.
-- Register `/plan` in Telegram bot command menu via `set_my_commands`.
-- Add `.gitignore` rules for user data (`sessions/`, `memory/`, `*.jsonl`).
-- 20 new tests (unit + integration) covering dedup, loop detection, plan command, and plan detection.
+- **Tool call dedup**: identical tool calls within a turn are cached and executed only once.
+- **Search loop detection**: 3+ consecutive `web_search` calls trigger a system nudge to stop and synthesize.
+- **`/plan` & `/normal` mode toggle**: `/plan` switches the session to plan mode — all subsequent messages auto-generate a structured TODO-style plan before execution. `/normal` switches back to direct execution. Mode persists across messages via `session.metadata`.
+- **Plan skill** (`always: true`): teaches the agent to auto-plan for complex tasks (3+ steps, research, comparison) even in normal mode.
+- **PLAN → SEARCH → FETCH → SYNTHESIZE** workflow guidance in system prompt; search results include `web_fetch` hint.
+- New modules: `orchestrator/dedup.py`, `skills/plan/SKILL.md`. Telegram registers `/plan` and `/normal` commands.
 
 ### v0.1 — Web Search Quality & Multi-Source Fusion
 

--- a/snapagent/agent/loop.py
+++ b/snapagent/agent/loop.py
@@ -413,8 +413,10 @@ class AgentLoop:
                 channel=msg.channel,
                 chat_id=msg.chat_id,
                 content=(
-                    "\U0001f4cb Plan mode ON — I'll create a step-by-step plan before acting.\n"
-                    "Use /normal to switch back."
+                    "\U0001f4cb Plan mode ON\n"
+                    "I'll clarify requirements and present a plan for your approval "
+                    "before taking any action.\n"
+                    "Use /normal to switch back to direct execution."
                 ),
             )
         if cmd == "/normal":
@@ -436,8 +438,9 @@ class AgentLoop:
                 sender_id=msg.sender_id,
                 chat_id=msg.chat_id,
                 content=(
-                    "[Plan Mode] Generate a structured plan first, "
-                    "then execute it step by step.\n\n" + msg.content
+                    "[Plan Mode] First clarify the requirements, then present a structured plan "
+                    "and WAIT for the user to approve, modify, or reject it before executing.\n\n"
+                    + msg.content
                 ),
                 timestamp=msg.timestamp,
                 media=msg.media,

--- a/snapagent/channels/telegram.py
+++ b/snapagent/channels/telegram.py
@@ -114,7 +114,8 @@ class TelegramChannel(BaseChannel):
     BOT_COMMANDS = [
         BotCommand("start", "Start the bot"),
         BotCommand("new", "Start a new conversation"),
-        BotCommand("plan", "Plan before acting on complex tasks"),
+        BotCommand("plan", "Switch to plan mode (think first, then act)"),
+        BotCommand("normal", "Switch to normal mode (execute directly)"),
         BotCommand("stop", "Stop the current task"),
         BotCommand("help", "Show available commands"),
     ]

--- a/snapagent/channels/telegram.py
+++ b/snapagent/channels/telegram.py
@@ -157,6 +157,8 @@ class TelegramChannel(BaseChannel):
         # Add command handlers
         self._app.add_handler(CommandHandler("start", self._on_start))
         self._app.add_handler(CommandHandler("new", self._forward_command))
+        self._app.add_handler(CommandHandler("plan", self._forward_command))
+        self._app.add_handler(CommandHandler("normal", self._forward_command))
         self._app.add_handler(CommandHandler("stop", self._on_stop))
         self._app.add_handler(CommandHandler("help", self._on_help))
 
@@ -367,6 +369,8 @@ class TelegramChannel(BaseChannel):
         await update.message.reply_text(
             "🐈 snapagent commands:\n"
             "/new — Start a new conversation\n"
+            "/plan — Switch to plan mode (think first, then act)\n"
+            "/normal — Switch to normal mode (execute directly)\n"
             "/stop — Stop the current task\n"
             "/help — Show available commands"
         )

--- a/snapagent/skills/plan/SKILL.md
+++ b/snapagent/skills/plan/SKILL.md
@@ -9,16 +9,23 @@ always: true
 ## When to Plan
 
 Generate a structured plan before acting when ANY of these apply:
-- The user explicitly uses `/plan` or sends `[Plan Mode]` (always plan)
+- The message contains `[Plan Mode]` (always plan)
 - The request requires 3+ distinct steps or tool calls
 - The request involves research, comparison, or synthesis
 - The request combines multiple independent sub-tasks
 
 Do NOT plan for simple questions, greetings, single-tool tasks, or casual conversation.
 
-## Plan Format
+## Plan Workflow
 
-Output a plan block BEFORE making any tool calls:
+### Step 1: Clarify Requirements
+Before creating a plan, briefly confirm your understanding of the request:
+- Restate the goal in one sentence
+- List any assumptions you are making
+- Ask clarifying questions if the request is ambiguous
+
+### Step 2: Present the Plan
+Output a plan block and **stop — do NOT execute any tools yet**:
 
 ```
 **Plan:**
@@ -27,15 +34,20 @@ Output a plan block BEFORE making any tool calls:
 3. [ ] Step description
 ```
 
+Then ask: "Does this plan look good? You can approve, modify, or reject it."
+
 Rules:
 - Each step is a single, concrete action
 - Include the primary tool in parentheses when applicable
 - Keep to 3–7 steps; collapse trivial sub-steps
-- After outputting the plan, execute it step by step
-- Do NOT re-output the entire plan after each step
 
-## Execution
+### Step 3: Wait for User Approval
+- If the user approves (e.g. "ok", "go", "approved", "yes", "do it"): execute the plan step by step
+- If the user suggests changes: revise the plan and present it again
+- If the user rejects: abandon the plan and ask what they'd like instead
 
+### Step 4: Execute
+Once approved:
 - State which step you are working on before each tool call
 - After each step, evaluate whether the remaining plan still makes sense
 - Skip steps that become unnecessary based on new information


### PR DESCRIPTION
## Summary

- **Tool call dedup** — per-turn cache prevents identical tool calls from re-executing, saving API quota
- **Search loop detection** — 3+ consecutive `web_search` calls inject system nudge to stop and synthesize
- **`/plan` & `/normal` mode toggle** — `/plan` switches session to plan mode, all subsequent messages auto-generate TODO-style plan before execution; `/normal` switches back. Mode persists via `session.metadata`
- **Plan skill** (`always: true`) — agent auto-plans for complex tasks even in normal mode
- **PLAN → SEARCH → FETCH → SYNTHESIZE** workflow in system prompt; search results include `web_fetch` hint

## New files

| File | Description |
|------|-------------|
| `orchestrator/dedup.py` | Tool call dedup cache + search loop detector |
| `skills/plan/SKILL.md` | Plan skill (`always: true`) |

## Modified

| File | Change |
|------|--------|
| `agent/loop.py` | `/plan`, `/normal` command dispatch + mode injection |
| `orchestrator/conversation.py` | Dedup wiring + plan block detection in progress |
| `agent/context.py` | Web research strategy in system prompt |
| `agent/tools/web.py` | `web_fetch` hint in search results |
| `channels/telegram.py` | Register `/plan` `/normal` in bot menu |
| `.gitignore` | Protect user data (sessions, memory, jsonl) |

## Tests

165 passed — 20 new tests covering dedup, loop detection, plan command, plan detection.