### PR TITLE
feat(observability): Track 0 event backbone foundation

### DIFF
--- a/snapagent/bus/events.py
+++ b/snapagent/bus/events.py
@@ -17,6 +17,8 @@ class InboundMessage:
     media: list[str] = field(default_factory=list)  # Media URLs
     metadata: dict[str, Any] = field(default_factory=dict)  # Channel-specific data
     session_key_override: str | None = None  # Optional override for thread-scoped sessions
+    run_id: str | None = None  # Correlation ID for one end-to-end run
+    turn_id: str | None = None  # Correlation ID for one model/tool turn
 
     @property
     def session_key(self) -> str:
@@ -34,3 +36,5 @@ class OutboundMessage:
     reply_to: str | None = None
     media: list[str] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
+    run_id: str | None = None
+    turn_id: str | None = None

--- a/snapagent/bus/queue.py
+++ b/snapagent/bus/queue.py
@@ -1,8 +1,12 @@
 """Async message queue for decoupled channel-agent communication."""
 
 import asyncio
+from typing import Awaitable, Callable
 
 from snapagent.bus.events import InboundMessage, OutboundMessage
+from snapagent.core.types import DiagnosticEvent
+
+EventEmitter = Callable[[DiagnosticEvent], Awaitable[None]]
 
 
 class MessageBus:
@@ -13,14 +17,40 @@ class MessageBus:
     them and pushes responses to the outbound queue.
     """
 
-    def __init__(self):
+    def __init__(self, event_emitter: EventEmitter | None = None):
         self.inbound: asyncio.Queue[InboundMessage] = asyncio.Queue()
         self.outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue()
         self._event_channels: dict[str, asyncio.Queue[str]] = {}
+        self._event_emitter = event_emitter
+
+    def set_event_emitter(self, event_emitter: EventEmitter | None) -> None:
+        """Install or replace diagnostic event emitter."""
+        self._event_emitter = event_emitter
+
+    async def _emit(self, event: DiagnosticEvent) -> None:
+        if not self._event_emitter:
+            return
+        try:
+            await self._event_emitter(event)
+        except Exception:
+            # Observability must never block message flow.
+            return
 
     async def publish_inbound(self, msg: InboundMessage) -> None:
         """Publish a message from a channel to the agent."""
         await self.inbound.put(msg)
+        await self._emit(
+            DiagnosticEvent(
+                name="inbound.received",
+                component="bus.queue",
+                status="ok",
+                session_key=msg.session_key,
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                run_id=msg.run_id,
+                turn_id=msg.turn_id,
+            )
+        )
 
     async def consume_inbound(self) -> InboundMessage:
         """Consume the next inbound message (blocks until available)."""
@@ -29,6 +59,17 @@ class MessageBus:
     async def publish_outbound(self, msg: OutboundMessage) -> None:
         """Publish a response from the agent to channels."""
         await self.outbound.put(msg)
+        await self._emit(
+            DiagnosticEvent(
+                name="outbound.published",
+                component="bus.queue",
+                status="ok",
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                run_id=msg.run_id,
+                turn_id=msg.turn_id,
+            )
+        )
 
     async def consume_outbound(self) -> OutboundMessage:
         """Consume the next outbound message (blocks until available)."""
@@ -62,6 +103,18 @@ class MessageBus:
         if session_key not in self._event_channels:
             self._event_channels[session_key] = asyncio.Queue()
         await self._event_channels[session_key].put(content)
+        channel, chat_id = (session_key.split(":", 1) + [None])[:2]
+        await self._emit(
+            DiagnosticEvent(
+                name="session.event.published",
+                component="bus.queue",
+                status="ok",
+                session_key=session_key,
+                channel=channel,
+                chat_id=chat_id,
+                attrs={"content": content},
+            )
+        )
 
     async def check_events(self, session_key: str) -> str | None:
         """Drain accumulated events for a session without blocking."""

--- a/snapagent/core/types.py
+++ b/snapagent/core/types.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any
+from uuid import uuid4
 
 
 @dataclass(slots=True)
@@ -21,6 +23,49 @@ class InputEnvelope:
     @property
     def session_key(self) -> str:
         return self.session_key_override or f"{self.channel}:{self.chat_id}"
+
+
+@dataclass(slots=True)
+class DiagnosticEvent:
+    """Structured observability event emitted by the runtime."""
+
+    name: str
+    component: str
+    severity: str = "info"
+    event_id: str = field(default_factory=lambda: uuid4().hex)
+    ts: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    session_key: str | None = None
+    channel: str | None = None
+    chat_id: str | None = None
+    run_id: str | None = None
+    turn_id: str | None = None
+    operation: str | None = None
+    status: str | None = None
+    latency_ms: float | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    attrs: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable payload."""
+        return {
+            "event_id": self.event_id,
+            "ts": self.ts.isoformat(),
+            "name": self.name,
+            "component": self.component,
+            "severity": self.severity,
+            "session_key": self.session_key,
+            "channel": self.channel,
+            "chat_id": self.chat_id,
+            "run_id": self.run_id,
+            "turn_id": self.turn_id,
+            "operation": self.operation,
+            "status": self.status,
+            "latency_ms": self.latency_ms,
+            "error_code": self.error_code,
+            "error_message": self.error_message,
+            "attrs": self.attrs,
+        }
 
 
 @dataclass(slots=True)

--- a/tests/test_observability_event_backbone.py
+++ b/tests/test_observability_event_backbone.py
@@ -1,0 +1,116 @@
+"""Tests for Track 0 observability event backbone foundation."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from snapagent.bus.events import InboundMessage, OutboundMessage
+from snapagent.bus.queue import MessageBus
+from snapagent.core.types import DiagnosticEvent
+
+
+@pytest.mark.asyncio
+async def test_message_bus_emits_diagnostic_events() -> None:
+    captured: list[DiagnosticEvent] = []
+
+    async def _emit(ev: DiagnosticEvent) -> None:
+        captured.append(ev)
+
+    bus = MessageBus(event_emitter=_emit)
+
+    inbound = InboundMessage(
+        channel="telegram",
+        sender_id="u1",
+        chat_id="c1",
+        content="hello",
+        run_id="run-1",
+        turn_id="turn-1",
+    )
+    await bus.publish_inbound(inbound)
+
+    outbound = OutboundMessage(
+        channel="telegram",
+        chat_id="c1",
+        content="world",
+        run_id="run-1",
+        turn_id="turn-1",
+    )
+    await bus.publish_outbound(outbound)
+
+    names = [e.name for e in captured]
+    assert "inbound.received" in names
+    assert "outbound.published" in names
+    assert captured[0].run_id == "run-1"
+    assert captured[0].turn_id == "turn-1"
+
+
+def test_diagnostic_event_schema_fields() -> None:
+    ev = DiagnosticEvent(name="turn.started", component="agent.loop", status="ok")
+
+    payload = ev.to_dict()
+
+    assert payload["name"] == "turn.started"
+    assert payload["component"] == "agent.loop"
+    assert payload["status"] == "ok"
+    assert payload["event_id"]
+    assert payload["ts"]
+
+
+@pytest.mark.asyncio
+async def test_message_bus_emitter_failure_isolated() -> None:
+    async def _boom(_: DiagnosticEvent) -> None:
+        raise RuntimeError("boom")
+
+    bus = MessageBus(event_emitter=_boom)
+    await bus.publish_inbound(
+        InboundMessage(channel="cli", sender_id="u", chat_id="c", content="x")
+    )
+
+    got = await asyncio.wait_for(bus.consume_inbound(), timeout=1.0)
+    assert got.content == "x"
+
+
+def _make_loop():
+    from snapagent.agent.loop import AgentLoop
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with (
+        patch("snapagent.agent.loop.ContextBuilder"),
+        patch("snapagent.agent.loop.SessionManager"),
+        patch("snapagent.agent.loop.SubagentManager") as mock_sub_mgr,
+    ):
+        mock_sub_mgr.return_value.cancel_by_session = AsyncMock(return_value=0)
+        loop = AgentLoop(bus=bus, provider=provider, workspace=workspace)
+    return loop
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_assigns_and_propagates_correlation_ids() -> None:
+    loop = _make_loop()
+
+    session = MagicMock()
+    session.key = "cli:direct"
+    session.metadata = {}
+    session.messages = []
+    session.last_consolidated = 0
+    session.get_history.return_value = []
+
+    loop.sessions.get_or_create.return_value = session
+    loop.sessions.save.return_value = None
+    loop._build_initial_messages = MagicMock(return_value=([{"role": "user", "content": "hi"}], {}))
+    loop._run_agent_loop = AsyncMock(return_value=("done", [], [{"role": "assistant", "content": "done"}]))
+
+    msg = InboundMessage(channel="cli", sender_id="user", chat_id="direct", content="hello")
+    out = await loop._process_message(msg)
+
+    assert out is not None
+    assert out.run_id is not None
+    assert out.turn_id is not None


### PR DESCRIPTION
## Summary
- add `DiagnosticEvent` schema in core types for unified observability event payloads
- add optional diagnostic event emitter in `MessageBus` with no-op fallback and failure isolation
- propagate correlation IDs (`run_id` / `turn_id`) through inbound/outbound message flow in `AgentLoop`
- add focused tests for schema, emitter behavior, and correlation propagation

## Issue
- Closes #8

## Test Plan
- `/home/rickthemad4/SnapAgent/.venv/bin/python -m pytest -q tests/test_observability_event_backbone.py`
- `/home/rickthemad4/SnapAgent/.venv/bin/python -m pytest -q tests/test_event_injection.py tests/test_task_cancel.py tests/test_orchestrator_dedup.py tests/test_react_trace.py`
- `/home/rickthemad4/SnapAgent/.venv/bin/ruff check snapagent/core/types.py snapagent/bus/events.py snapagent/bus/queue.py snapagent/agent/loop.py tests/test_observability_event_backbone.py`

## Notes
- full-suite run is still blocked by optional Matrix dependency in this environment (`nh3` missing during collection)
