### PR TITLE
feat(observability): Track 2 logging surface (JSONL + query/tail + redaction)

### DIFF
--- a/snapagent/observability/__init__.py
+++ b/snapagent/observability/__init__.py
@@ -1,0 +1,6 @@
+"""Observability helpers for logging and redaction."""
+
+from snapagent.observability.logging_sink import JsonlLoggingSink
+from snapagent.observability.redaction import REDACTED, redact_payload
+
+__all__ = ["JsonlLoggingSink", "REDACTED", "redact_payload"]

--- a/snapagent/observability/logging_sink.py
+++ b/snapagent/observability/logging_sink.py
@@ -1,0 +1,145 @@
+"""JSONL sink for diagnostic events."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from snapagent.core.types import DiagnosticEvent
+from snapagent.observability.redaction import redact_payload
+
+
+class JsonlLoggingSink:
+    """Append-only JSONL sink with basic rotation and filtering."""
+
+    def __init__(
+        self,
+        path: Path,
+        rotate_bytes: int = 5 * 1024 * 1024,
+        max_backups: int = 3,
+    ) -> None:
+        self.path = path
+        self.rotate_bytes = rotate_bytes
+        self.max_backups = max(0, max_backups)
+        self._lock = asyncio.Lock()
+
+    async def emit(self, event: DiagnosticEvent | dict[str, Any]) -> None:
+        """Append a redacted diagnostic event to the log."""
+        payload = event.to_dict() if isinstance(event, DiagnosticEvent) else dict(event)
+        redacted = redact_payload(payload)
+        line = json.dumps(redacted, ensure_ascii=False)
+
+        async with self._lock:
+            await asyncio.to_thread(self._append_line_sync, line)
+
+    def _append_line_sync(self, line: str) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        encoded = (line + "\n").encode("utf-8")
+        if self.path.exists() and self.path.stat().st_size + len(encoded) > self.rotate_bytes:
+            self._rotate_sync()
+        with self.path.open("ab") as handle:
+            handle.write(encoded)
+
+    def _rotate_sync(self) -> None:
+        if self.max_backups <= 0:
+            if self.path.exists():
+                self.path.unlink()
+            return
+
+        oldest = self.path.with_suffix(f"{self.path.suffix}.{self.max_backups}")
+        if oldest.exists():
+            oldest.unlink()
+
+        for index in range(self.max_backups - 1, 0, -1):
+            src = self.path.with_suffix(f"{self.path.suffix}.{index}")
+            dst = self.path.with_suffix(f"{self.path.suffix}.{index + 1}")
+            if src.exists():
+                src.replace(dst)
+
+        if self.path.exists():
+            self.path.replace(self.path.with_suffix(f"{self.path.suffix}.1"))
+
+    def _iter_log_files(self) -> list[Path]:
+        files: list[Path] = []
+        for index in range(self.max_backups, 0, -1):
+            candidate = self.path.with_suffix(f"{self.path.suffix}.{index}")
+            if candidate.exists():
+                files.append(candidate)
+        if self.path.exists():
+            files.append(self.path)
+        return files
+
+    @staticmethod
+    def _matches(
+        event: dict[str, Any],
+        *,
+        session_key: str | None,
+        run_id: str | None,
+    ) -> bool:
+        if session_key and event.get("session_key") != session_key:
+            return False
+        if run_id and event.get("run_id") != run_id:
+            return False
+        return True
+
+    @staticmethod
+    def _decode_line(raw: str) -> dict[str, Any] | None:
+        line = raw.strip()
+        if not line:
+            return None
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def query(
+        self,
+        *,
+        session_key: str | None = None,
+        run_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return latest matching events from JSONL logs."""
+        if limit <= 0:
+            return []
+
+        rows: list[dict[str, Any]] = []
+        for path in self._iter_log_files():
+            with path.open(encoding="utf-8") as handle:
+                for raw in handle:
+                    event = self._decode_line(raw)
+                    if not event:
+                        continue
+                    if self._matches(event, session_key=session_key, run_id=run_id):
+                        rows.append(event)
+                        if len(rows) > limit:
+                            rows = rows[-limit:]
+        return rows
+
+    def follow(
+        self,
+        *,
+        session_key: str | None = None,
+        run_id: str | None = None,
+        poll_interval: float = 0.5,
+    ):
+        """Yield new matching events in follow mode (tail -f style)."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.touch(exist_ok=True)
+
+        with self.path.open(encoding="utf-8") as handle:
+            handle.seek(0, 2)
+            while True:
+                raw = handle.readline()
+                if not raw:
+                    time.sleep(poll_interval)
+                    continue
+                event = self._decode_line(raw)
+                if not event:
+                    continue
+                if self._matches(event, session_key=session_key, run_id=run_id):
+                    yield event

--- a/snapagent/observability/redaction.py
+++ b/snapagent/observability/redaction.py
@@ -1,0 +1,77 @@
+"""Redaction helpers for observability payloads."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+REDACTED = "***REDACTED***"
+
+_SENSITIVE_KEYWORDS = (
+    "token",
+    "secret",
+    "password",
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+    "sessionid",
+    "private_key",
+)
+
+_EMAIL_RE = re.compile(r"\b([A-Za-z0-9._%+-]+)@([A-Za-z0-9.-]+\.[A-Za-z]{2,})\b")
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._\-]+\b")
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"\bsk-[A-Za-z0-9]{8,}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"),
+)
+
+
+def _is_sensitive_key(key: str | None) -> bool:
+    if not key:
+        return False
+    normalized = key.lower().replace("-", "_")
+    return any(token in normalized for token in _SENSITIVE_KEYWORDS)
+
+
+def _mask_email(match: re.Match[str]) -> str:
+    local = match.group(1)
+    domain = match.group(2)
+    head, _, suffix = domain.partition(".")
+
+    local_masked = f"{local[:1]}***" if local else "***"
+    head_masked = f"{head[:1]}***" if head else "***"
+    return f"{local_masked}@{head_masked}.{suffix}" if suffix else f"{local_masked}@{head_masked}"
+
+
+def _redact_text(text: str) -> str:
+    redacted = _EMAIL_RE.sub(_mask_email, text)
+    redacted = _BEARER_RE.sub(f"Bearer {REDACTED}", redacted)
+    for pattern in _SECRET_VALUE_PATTERNS:
+        redacted = pattern.sub(REDACTED, redacted)
+    return redacted
+
+
+def _redact(value: Any, key: str | None = None) -> Any:
+    if _is_sensitive_key(key):
+        return REDACTED
+
+    if isinstance(value, dict):
+        return {k: _redact(v, str(k)) for k, v in value.items()}
+
+    if isinstance(value, list):
+        return [_redact(item, key) for item in value]
+
+    if isinstance(value, tuple):
+        return tuple(_redact(item, key) for item in value)
+
+    if isinstance(value, str):
+        return _redact_text(value)
+
+    return value
+
+
+def redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a redacted copy of the observability payload."""
+    return _redact(payload)

--- a/tests/test_observability_logging_surface.py
+++ b/tests/test_observability_logging_surface.py
@@ -1,0 +1,134 @@
+"""Tests for Track 2 logging surface."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from typer.testing import CliRunner
+
+from snapagent.cli.commands import app
+from snapagent.core.types import DiagnosticEvent
+from snapagent.observability.logging_sink import JsonlLoggingSink
+from snapagent.observability.redaction import REDACTED, redact_payload
+
+runner = CliRunner()
+
+
+def test_redaction_masks_sensitive_fields() -> None:
+    payload = {
+        "attrs": {
+            "api_key": "sk-super-secret",
+            "cookie": "sessionid=abc",
+            "note": "Contact me at alice@example.com",
+        }
+    }
+
+    redacted = redact_payload(payload)
+
+    assert redacted["attrs"]["api_key"] == REDACTED
+    assert redacted["attrs"]["cookie"] == REDACTED
+    assert "alice@example.com" not in redacted["attrs"]["note"]
+
+
+def test_jsonl_sink_is_append_only_and_queryable(tmp_path) -> None:
+    sink = JsonlLoggingSink(tmp_path / "logs" / "diagnostic.jsonl")
+
+    asyncio.run(
+        sink.emit(
+            DiagnosticEvent(
+                name="inbound.received",
+                component="bus.queue",
+                session_key="cli:chat-a",
+                run_id="run-a",
+                attrs={"api_key": "sk-abc123"},
+            )
+        )
+    )
+    asyncio.run(
+        sink.emit(
+            DiagnosticEvent(
+                name="outbound.published",
+                component="bus.queue",
+                session_key="cli:chat-b",
+                run_id="run-b",
+            )
+        )
+    )
+
+    filtered = sink.query(session_key="cli:chat-a", run_id="run-a", limit=10)
+    all_rows = sink.query(limit=10)
+
+    assert len(filtered) == 1
+    assert filtered[0]["session_key"] == "cli:chat-a"
+    assert filtered[0]["run_id"] == "run-a"
+    assert filtered[0]["attrs"]["api_key"] == REDACTED
+    assert len(all_rows) == 2
+
+
+def test_logs_command_supports_filters_and_json_output(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("snapagent.config.loader.get_data_dir", lambda: tmp_path)
+    sink = JsonlLoggingSink(tmp_path / "logs" / "diagnostic.jsonl")
+
+    asyncio.run(
+        sink.emit(
+            DiagnosticEvent(
+                name="inbound.received",
+                component="bus.queue",
+                session_key="cli:chat-1",
+                run_id="run-keep",
+                attrs={"token": "tok-123"},
+            )
+        )
+    )
+    asyncio.run(
+        sink.emit(
+            DiagnosticEvent(
+                name="inbound.received",
+                component="bus.queue",
+                session_key="cli:chat-2",
+                run_id="run-drop",
+            )
+        )
+    )
+
+    result = runner.invoke(
+        app,
+        ["logs", "--session", "cli:chat-1", "--run", "run-keep", "--json", "--lines", "10"],
+    )
+
+    assert result.exit_code == 0
+    rows = [line for line in result.stdout.splitlines() if line.startswith("{")]
+    assert len(rows) == 1
+    payload = json.loads(rows[0])
+    assert payload["session_key"] == "cli:chat-1"
+    assert payload["run_id"] == "run-keep"
+    assert payload["attrs"]["token"] == REDACTED
+
+
+def test_logs_command_supports_follow_mode(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("snapagent.config.loader.get_data_dir", lambda: tmp_path)
+
+    def _fake_query(self, **kwargs):
+        return []
+
+    def _fake_follow(self, **kwargs):
+        yield {
+            "ts": "2026-02-27T00:00:00+00:00",
+            "name": "outbound.published",
+            "component": "bus.queue",
+            "severity": "info",
+            "session_key": "cli:chat-1",
+            "run_id": "run-1",
+            "turn_id": "turn-1",
+            "status": "ok",
+            "attrs": {},
+        }
+
+    monkeypatch.setattr(JsonlLoggingSink, "query", _fake_query)
+    monkeypatch.setattr(JsonlLoggingSink, "follow", _fake_follow)
+
+    result = runner.invoke(app, ["logs", "--follow", "--json"])
+
+    assert result.exit_code == 0
+    assert '"name": "outbound.published"' in result.stdout


### PR DESCRIPTION
## Summary
- add structured JSONL diagnostic sink with append-only writes, size-based rotation, and `session_key` / `run_id` query support
- add redaction layer to mask sensitive values (token/api key/cookie/secret-like keys and inline secret/email patterns)
- add `snapagent logs` CLI command with `--follow`, `--session`, `--run`, and `--json`
- wire runtime event emission in `gateway`, `agent`, and `cron run` paths to persist diagnostic events to logs
- add focused tests for redaction, sink query behavior, CLI filtering, and follow mode

## Issue
- Refs #10

## Test Plan
- `.venv/bin/pytest tests/test_observability_logging_surface.py -q`
- `.venv/bin/pytest tests/test_commands.py tests/test_observability_event_backbone.py tests/test_cron_commands.py -q`
- `.venv/bin/pytest tests/ --ignore=tests/test_matrix_channel.py -q`
- `.venv/bin/ruff check snapagent/cli/commands.py snapagent/observability/logging_sink.py snapagent/observability/redaction.py tests/test_observability_logging_surface.py`
