### PR TITLE
feat(doctor): add codex-driven /doctor connector (health/status/logs/events)

### DIFF
--- a/docs/plans/2026-02-27-doctor-codex-connector.md
+++ b/docs/plans/2026-02-27-doctor-codex-connector.md
@@ -1,0 +1,131 @@
+# Doctor Connector (Codex-Driven) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a slim `/doctor` connector that pauses the current session task, lets Codex decide which built-in diagnostics to run, and reports evidence-first diagnosis in chat.
+
+**Architecture:** Keep SnapAgent as a thin control plane. `AgentLoop` handles `/doctor` lifecycle and session isolation, while Codex drives investigation by calling a new read-only diagnostic tool (`doctor_check`) for `health`, `status`, `logs`, and `events`. No OTel scope in this iteration.
+
+**Tech Stack:** Python 3.11, Typer/CLI internals, AgentLoop + ToolRegistry, existing observability modules (`health`, `JsonlLoggingSink`), pytest.
+
+---
+
+## Task 1: Add doctor command lifecycle in AgentLoop
+
+**Files:**
+- Modify: `snapagent/agent/loop.py`
+- Test: `tests/test_doctor_command.py`
+
+**Step 1: Write failing tests for doctor commands**
+- Add tests for:
+  - `/doctor` starts doctor mode and cancels current session tasks.
+  - `/doctor status` reports current doctor state.
+  - `/doctor cancel` cancels doctor diagnostics for this session.
+  - `/help` includes doctor commands.
+
+**Step 2: Run tests to verify RED**
+- Run: `pytest -q tests/test_doctor_command.py`
+- Expected: FAIL due to missing `/doctor` behavior.
+
+**Step 3: Implement minimal doctor lifecycle**
+- In `run()`, route `/doctor...` to a dedicated handler (same priority level as `/stop`).
+- Reuse existing cancellation logic so `/doctor` pauses current session work before diagnostics.
+- Track per-session doctor task state in memory.
+- Expose `/doctor`, `/doctor status`, `/doctor cancel`, `/doctor resume`.
+
+**Step 4: Run tests to verify GREEN**
+- Run: `pytest -q tests/test_doctor_command.py`
+- Expected: PASS.
+
+**Step 5: Commit**
+- `git add snapagent/agent/loop.py tests/test_doctor_command.py`
+- `git commit -m "feat(agent): add /doctor session lifecycle and command routing"`
+
+## Task 2: Add read-only doctor diagnostics tool
+
+**Files:**
+- Create: `snapagent/agent/tools/doctor.py`
+- Modify: `snapagent/agent/loop.py` (tool registration)
+- Test: `tests/test_doctor_tool.py`
+
+**Step 1: Write failing tests for tool behavior**
+- Add tests for `doctor_check`:
+  - `check=health` returns deep health snapshot payload.
+  - `check=status` returns status payload with config/workspace context.
+  - `check=logs` filters by session/run and respects line limits.
+  - `check=events` returns timeline-oriented event rows.
+
+**Step 2: Run tests to verify RED**
+- Run: `pytest -q tests/test_doctor_tool.py`
+- Expected: FAIL because tool does not exist.
+
+**Step 3: Implement tool**
+- Implement one tool with strict enum-based checks:
+  - `health`
+  - `status`
+  - `logs`
+  - `events`
+- Reuse existing internals (no shell command spawning in tool body).
+- Keep tool read-only and JSON output only.
+
+**Step 4: Run tests to verify GREEN**
+- Run: `pytest -q tests/test_doctor_tool.py`
+- Expected: PASS.
+
+**Step 5: Commit**
+- `git add snapagent/agent/tools/doctor.py snapagent/agent/loop.py tests/test_doctor_tool.py`
+- `git commit -m "feat(agent): add doctor_check observability tool"`
+
+## Task 3: Wire doctor UX copy and channel help text
+
+**Files:**
+- Modify: `snapagent/agent/loop.py`
+- Modify: `snapagent/channels/telegram.py`
+- Test: `tests/test_plan_command.py` (or dedicated command text test)
+
+**Step 1: Write failing assertions**
+- Verify `/help` includes doctor command list in core loop response.
+- Verify Telegram help output includes doctor commands.
+
+**Step 2: Run tests to verify RED**
+- Run targeted tests and confirm missing text assertions fail.
+
+**Step 3: Implement minimal copy updates**
+- Add doctor command lines to help output.
+- Keep copy concise and platform-neutral.
+
+**Step 4: Run tests to verify GREEN**
+- Run targeted tests and confirm pass.
+
+**Step 5: Commit**
+- `git add snapagent/agent/loop.py snapagent/channels/telegram.py tests/...`
+- `git commit -m "chore(help): document /doctor commands in chat help"`
+
+## Task 4: Verification, PR, and independent review loop
+
+**Files:**
+- Modify PR description/checklist on GitHub
+
+**Step 1: Run verification suite**
+- Run:
+  - `pytest -q tests/test_doctor_command.py tests/test_doctor_tool.py tests/test_task_cancel.py tests/test_plan_command.py tests/test_commands.py`
+  - optional broader smoke: `pytest -q tests/test_health_surface.py tests/test_observability_logging_surface.py tests/test_observability_event_backbone.py`
+
+**Step 2: Push and open PR**
+- Push branch and create PR to `release`.
+
+**Step 3: Spawn external review subagent**
+- Ask subagent to review PR diff and post GitHub comments.
+
+**Step 4: Apply feedback and iterate**
+- Fix issues from subagent review.
+- Spawn a fresh review subagent again.
+- Repeat until no blocking findings remain.
+
+## Explicit Non-Goals (M0)
+- No OTel integration.
+- No auto code rewrite/restart by doctor.
+- No cross-platform button workflow.
+
+## TODO (deferred by request)
+- Add hard permission boundaries for doctor actions (tool allowlist policies, role-based authorization, high-risk confirmations).

--- a/snapagent/agent/loop.py
+++ b/snapagent/agent/loop.py
@@ -275,10 +275,11 @@ class AgentLoop:
                 continue
 
             raw = msg.content.strip()
-            lowered = raw.lower()
-            if lowered == "/stop":
+            parts = raw.split(maxsplit=1)
+            command = parts[0].lower() if parts else ""
+            if command == "/stop":
                 await self._handle_stop(msg)
-            elif lowered.startswith("/doctor"):
+            elif command == "/doctor":
                 await self._handle_doctor(msg)
             else:
                 if self.enable_event_handling and msg.session_key in self._processing_tasks:
@@ -312,7 +313,8 @@ class AgentLoop:
         session = self.sessions.get_or_create(key)
         text = msg.content.strip()
         lowered = text.lower()
-        action = lowered.split(maxsplit=2)[1] if len(lowered.split()) > 1 else "start"
+        parts = lowered.split(maxsplit=2)
+        action = parts[1] if len(parts) > 1 else "start"
 
         if action == "status":
             task = self._doctor_tasks.get(key)

--- a/snapagent/agent/tools/doctor.py
+++ b/snapagent/agent/tools/doctor.py
@@ -1,0 +1,142 @@
+"""Read-only doctor diagnostics tool."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from snapagent.agent.tools.base import Tool
+from snapagent.config.loader import get_config_path, get_data_dir, load_config
+from snapagent.observability.health import collect_health_snapshot
+from snapagent.observability.logging_sink import JsonlLoggingSink
+
+
+class DoctorCheckTool(Tool):
+    """Expose built-in observability checks for Codex-driven diagnostics."""
+
+    @property
+    def name(self) -> str:
+        return "doctor_check"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Run read-only SnapAgent diagnostics. "
+            "Supports health, status, logs, and events checks."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "check": {
+                    "type": "string",
+                    "enum": ["health", "status", "logs", "events"],
+                    "description": "Which diagnostic check to run.",
+                },
+                "session_key": {
+                    "type": "string",
+                    "description": "Optional session filter, e.g. telegram:12345.",
+                },
+                "run_id": {
+                    "type": "string",
+                    "description": "Optional run correlation filter.",
+                },
+                "lines": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 500,
+                    "description": "Max rows for logs/events checks.",
+                },
+            },
+            "required": ["check"],
+        }
+
+    async def execute(
+        self,
+        *,
+        check: str,
+        session_key: str | None = None,
+        run_id: str | None = None,
+        lines: int = 120,
+    ) -> str:
+        limit = max(1, min(lines, 500))
+        if check == "health":
+            return self._health_payload()
+        if check == "status":
+            return self._status_payload()
+        if check == "logs":
+            return self._logs_payload(session_key=session_key, run_id=run_id, limit=limit)
+        if check == "events":
+            return self._events_payload(session_key=session_key, run_id=run_id, limit=limit)
+        return f"Error: unknown check '{check}'"
+
+    def _health_payload(self) -> str:
+        config_path = get_config_path()
+        config = load_config()
+        snapshot = collect_health_snapshot(config=config, config_path=config_path).to_dict(deep=True)
+        payload = {
+            "check": "health",
+            "snapshot": snapshot,
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+    def _status_payload(self) -> str:
+        config_path = get_config_path()
+        config = load_config()
+        snapshot = collect_health_snapshot(config=config, config_path=config_path).to_dict(deep=True)
+        payload = {
+            "check": "status",
+            "config_path": str(config_path),
+            "workspace": str(config.workspace_path),
+            "snapshot": snapshot,
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+    def _logs_payload(self, *, session_key: str | None, run_id: str | None, limit: int) -> str:
+        sink = JsonlLoggingSink(self._log_path())
+        rows = sink.query(session_key=session_key, run_id=run_id, limit=limit)
+        payload = {
+            "check": "logs",
+            "session_key": session_key,
+            "run_id": run_id,
+            "count": len(rows),
+            "rows": rows,
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+    def _events_payload(self, *, session_key: str | None, run_id: str | None, limit: int) -> str:
+        sink = JsonlLoggingSink(self._log_path())
+        rows = sink.query(session_key=session_key, run_id=run_id, limit=limit)
+        events = [
+            {
+                "ts": row.get("ts"),
+                "name": row.get("name"),
+                "component": row.get("component"),
+                "severity": row.get("severity"),
+                "status": row.get("status"),
+                "session_key": row.get("session_key"),
+                "run_id": row.get("run_id"),
+                "turn_id": row.get("turn_id"),
+                "operation": row.get("operation"),
+                "latency_ms": row.get("latency_ms"),
+                "error_code": row.get("error_code"),
+                "error_message": row.get("error_message"),
+                "attrs": row.get("attrs", {}),
+            }
+            for row in rows
+        ]
+        payload = {
+            "check": "events",
+            "session_key": session_key,
+            "run_id": run_id,
+            "count": len(events),
+            "events": events,
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+    @staticmethod
+    def _log_path() -> Path:
+        return get_data_dir() / "logs" / "diagnostic.jsonl"

--- a/snapagent/channels/telegram.py
+++ b/snapagent/channels/telegram.py
@@ -117,6 +117,7 @@ class TelegramChannel(BaseChannel):
         BotCommand("plan", "Switch to plan mode (think first, then act)"),
         BotCommand("normal", "Switch to normal mode (execute directly)"),
         BotCommand("stop", "Stop the current task"),
+        BotCommand("doctor", "Pause current session and run diagnostics"),
         BotCommand("help", "Show available commands"),
     ]
 

--- a/tests/test_doctor_command.py
+++ b/tests/test_doctor_command.py
@@ -1,0 +1,98 @@
+"""Tests for /doctor command lifecycle in AgentLoop."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from snapagent.bus.events import InboundMessage
+from snapagent.session.manager import Session
+
+
+def _make_loop():
+    from snapagent.agent.loop import AgentLoop
+    from snapagent.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with (
+        patch("snapagent.agent.loop.ContextBuilder"),
+        patch("snapagent.agent.loop.SessionManager"),
+        patch("snapagent.agent.loop.SubagentManager") as mock_sub_mgr,
+    ):
+        mock_sub_mgr.return_value.cancel_by_session = AsyncMock(return_value=0)
+        loop = AgentLoop(bus=bus, provider=provider, workspace=workspace)
+
+    session = Session(key="test:c1")
+    loop.sessions = MagicMock()
+    loop.sessions.get_or_create.return_value = session
+    loop.sessions.save = MagicMock()
+    loop._dispatch = AsyncMock(return_value=None)
+    return loop, bus, session
+
+
+@pytest.mark.asyncio
+async def test_doctor_start_cancels_session_tasks_and_enables_mode():
+    loop, bus, session = _make_loop()
+    cancelled = asyncio.Event()
+
+    async def slow_task():
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    task = asyncio.create_task(slow_task())
+    await asyncio.sleep(0)
+    loop._active_tasks["test:c1"] = [task]
+
+    msg = InboundMessage(channel="test", sender_id="u1", chat_id="c1", content="/doctor")
+    await loop._handle_doctor(msg)
+
+    assert cancelled.is_set()
+    assert session.metadata.get("doctor_mode") is True
+    out = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+    assert "doctor mode" in out.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_doctor_status_reports_idle():
+    loop, bus, _session = _make_loop()
+    msg = InboundMessage(channel="test", sender_id="u1", chat_id="c1", content="/doctor status")
+    await loop._handle_doctor(msg)
+    out = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+    assert "idle" in out.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_doctor_cancel_disables_mode():
+    loop, bus, session = _make_loop()
+    session.metadata["doctor_mode"] = True
+
+    task = asyncio.create_task(asyncio.sleep(60))
+    await asyncio.sleep(0)
+    loop._doctor_tasks["test:c1"] = task
+    loop._active_tasks["test:c1"] = [task]
+
+    msg = InboundMessage(channel="test", sender_id="u1", chat_id="c1", content="/doctor cancel")
+    await loop._handle_doctor(msg)
+
+    assert "doctor_mode" not in session.metadata
+    out = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+    assert "cancel" in out.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_help_includes_doctor_commands():
+    loop, _bus, _session = _make_loop()
+    msg = InboundMessage(channel="test", sender_id="u1", chat_id="c1", content="/help")
+    result = await loop._process_message(msg)
+    assert result is not None
+    assert "/doctor" in result.content

--- a/tests/test_doctor_tool.py
+++ b/tests/test_doctor_tool.py
@@ -1,0 +1,113 @@
+"""Tests for doctor_check observability tool."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from snapagent.config.schema import Config
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+@pytest.mark.asyncio
+async def test_doctor_tool_health_and_status(monkeypatch, tmp_path):
+    from snapagent.agent.tools.doctor import DoctorCheckTool
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    config = Config()
+    config.agents.defaults.workspace = str(workspace)
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+    data_dir = tmp_path / "data"
+
+    monkeypatch.setattr("snapagent.agent.tools.doctor.load_config", lambda: config)
+    monkeypatch.setattr("snapagent.agent.tools.doctor.get_config_path", lambda: config_path)
+    monkeypatch.setattr("snapagent.agent.tools.doctor.get_data_dir", lambda: data_dir)
+
+    tool = DoctorCheckTool()
+
+    health_payload = json.loads(await tool.execute(check="health"))
+    assert health_payload["check"] == "health"
+    assert "snapshot" in health_payload
+    assert "readiness" in health_payload["snapshot"]
+
+    status_payload = json.loads(await tool.execute(check="status"))
+    assert status_payload["check"] == "status"
+    assert status_payload["config_path"] == str(config_path)
+    assert status_payload["workspace"] == str(workspace)
+
+
+@pytest.mark.asyncio
+async def test_doctor_tool_logs_and_events(monkeypatch, tmp_path):
+    from snapagent.agent.tools.doctor import DoctorCheckTool
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    config = Config()
+    config.agents.defaults.workspace = str(workspace)
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+    data_dir = tmp_path / "data"
+    log_path = data_dir / "logs" / "diagnostic.jsonl"
+
+    rows = [
+        {
+            "ts": "2026-02-27T10:00:00Z",
+            "name": "inbound.received",
+            "component": "bus.queue",
+            "severity": "info",
+            "session_key": "telegram:1",
+            "run_id": "run-a",
+            "status": "ok",
+            "attrs": {"content": "hello"},
+        },
+        {
+            "ts": "2026-02-27T10:00:01Z",
+            "name": "outbound.published",
+            "component": "bus.queue",
+            "severity": "info",
+            "session_key": "telegram:1",
+            "run_id": "run-a",
+            "status": "ok",
+            "attrs": {},
+        },
+        {
+            "ts": "2026-02-27T10:00:02Z",
+            "name": "inbound.received",
+            "component": "bus.queue",
+            "severity": "info",
+            "session_key": "telegram:2",
+            "run_id": "run-b",
+            "status": "ok",
+            "attrs": {"content": "ignore"},
+        },
+    ]
+    _write_jsonl(log_path, rows)
+
+    monkeypatch.setattr("snapagent.agent.tools.doctor.load_config", lambda: config)
+    monkeypatch.setattr("snapagent.agent.tools.doctor.get_config_path", lambda: config_path)
+    monkeypatch.setattr("snapagent.agent.tools.doctor.get_data_dir", lambda: data_dir)
+
+    tool = DoctorCheckTool()
+
+    logs_payload = json.loads(
+        await tool.execute(check="logs", session_key="telegram:1", run_id="run-a", lines=10)
+    )
+    assert logs_payload["check"] == "logs"
+    assert logs_payload["count"] == 2
+
+    events_payload = json.loads(
+        await tool.execute(check="events", session_key="telegram:1", run_id="run-a", lines=10)
+    )
+    assert events_payload["check"] == "events"
+    assert events_payload["count"] == 2
+    assert all("name" in item for item in events_payload["events"])

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -7,3 +7,10 @@ def test_telegram_bot_commands_include_doctor():
     from snapagent.channels.telegram import TelegramChannel
 
     assert any(cmd.command == "doctor" for cmd in TelegramChannel.BOT_COMMANDS)
+
+
+def test_telegram_normalize_mention_command():
+    from snapagent.channels.telegram import TelegramChannel
+
+    normalized = TelegramChannel._normalize_command_text("/doctor@mybot status")
+    assert normalized == "/doctor status"

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -1,0 +1,9 @@
+"""Telegram command registration tests."""
+
+from __future__ import annotations
+
+
+def test_telegram_bot_commands_include_doctor():
+    from snapagent.channels.telegram import TelegramChannel
+
+    assert any(cmd.command == "doctor" for cmd in TelegramChannel.BOT_COMMANDS)


### PR DESCRIPTION
## Summary
- add a slim `/doctor` connector lifecycle in `AgentLoop`
  - `/doctor`: pause current session tasks and start diagnostic turn
  - `/doctor status`: show doctor task state
  - `/doctor cancel`: cancel session diagnostics
  - `/doctor resume`: exit doctor mode
- add read-only `doctor_check` tool for Codex-driven diagnostics:
  - `check=health`
  - `check=status`
  - `check=logs`
  - `check=events`
- update help text in core loop and Telegram command help
- add implementation plan doc in `docs/plans/2026-02-27-doctor-codex-connector.md`
- add tests for command lifecycle and tool behavior

## Why
Implements the agreed "方案2" architecture: keep SnapAgent thin as connector/control-plane, and let Codex decide what to inspect dynamically using bounded read-only diagnostics.

## Validation
- `PYTHONPATH=. /home/rickthemad4/SnapAgent/.venv/bin/pytest -q tests/test_doctor_command.py tests/test_doctor_tool.py tests/test_task_cancel.py tests/test_plan_command.py tests/test_commands.py tests/test_health_surface.py tests/test_observability_logging_surface.py tests/test_observability_event_backbone.py`
  - 50 passed

## Deferred TODO
- permission hardening for doctor actions (allowlist policy/RBAC/high-risk confirmation)