### PR TITLE
fix(ci): stabilize doctor command test under provider-precheck

### DIFF
--- a/tests/test_doctor_command.py
+++ b/tests/test_doctor_command.py
@@ -40,6 +40,7 @@ def _make_loop():
 @pytest.mark.asyncio
 async def test_doctor_start_cancels_session_tasks_and_enables_mode():
     loop, bus, session = _make_loop()
+    loop._doctor_setup_guidance = MagicMock(return_value=None)
     cancelled = asyncio.Event()
 
     async def slow_task():


### PR DESCRIPTION
## Root Cause
CI runs without local provider credentials. After adding doctor precheck guidance, `/doctor` can legitimately return a setup-blocked path (no `doctor_mode`), but one test still assumed `doctor_mode=True` unconditionally.

Failing test in CI:
- `tests/test_doctor_command.py::test_doctor_start_cancels_session_tasks_and_enables_mode`

## Fix
- In that test, explicitly mock precheck as ready:
  - `loop._doctor_setup_guidance = MagicMock(return_value=None)`
- This keeps the test focused on the intended behavior (cancel current task + enter doctor mode), independent of runner environment/provider setup.

## Verification
- `PYTHONPATH=. /home/rickthemad4/SnapAgent/.venv/bin/pytest -q tests/test_doctor_command.py`
  - 6 passed
- `PYTHONPATH=. /home/rickthemad4/SnapAgent/.venv/bin/pytest tests/ --ignore=tests/test_matrix_channel.py -q`
  - 292 passed
